### PR TITLE
feat: GenericNodeSelector to support custom, non DOM trees more easily

### DIFF
--- a/src/main/java/se/fishtank/css/selectors/generic/GenericNodeAdapter.java
+++ b/src/main/java/se/fishtank/css/selectors/generic/GenericNodeAdapter.java
@@ -1,0 +1,105 @@
+package se.fishtank.css.selectors.generic;
+
+import java.util.List;
+import java.util.Map;
+
+import se.fishtank.css.selectors.NodeSelectorException;
+
+/**
+ * This connects the GenericNodeSelector to whatever kind of Nodes you're using.
+ *
+ * @author Jens Hohmuth
+ */
+public interface GenericNodeAdapter<E> {
+    /**
+     * Get all attributes of the given Node as a map.
+     *
+     * @param e the Node to get attributes from
+     * @return
+     */
+    Map<String, String> getAttributes(E e);
+
+    /**
+     * Get all child nodes for the given node.
+     *
+     * @param e the Node to get child nodes for
+     * @return the child nodes of the given Node
+     */
+    List<E> getChildNodes(E e);
+
+    /**
+     * Return true if the given Node is considered to be empty. Check the DOM-implementation for an example. For many
+     * other node trees this might just always return false.
+     *
+     * @param e the Node to check
+     * @return true if the Node is empty and false if not
+     */
+    boolean isEmptyNode(E e);
+
+    /**
+     * Get the previous sibling of the given Node.
+     *
+     * @param e the Node to get the sibling for
+     * @return the previous sibling for the Node
+     */
+    E getPreviousSiblingElement(E e);
+
+    /**
+     * Get the next sibling of the given Node.
+     *
+     * @param e the Node to get the sibling for
+     * @return the next sibling for the given Node
+     */
+    E getNextSiblingElement(E e);
+
+    /**
+     * Get the name of the given Node.
+     *
+     * @param e the Node to get the name for
+     * @return the name of the Node
+     */
+    String getNodeName(E e);
+
+    /**
+     * Return the root node for the given Node.
+     *
+     * @param e the node to get the Node for
+     * @return the root node for the given Node
+     */
+    E getRootNode(E e);
+
+    /**
+     * Return all descendant nodes with the given tagName.
+     *
+     * @param e the Node to get the descendant nodes for
+     * @param tagName the tag name to return nodes
+     * @return the list of descendant Nodes with the given tag name
+     * @throws NodeSelectorException
+     */
+    List<E> getNodesByTagName(E e, String tagName) throws NodeSelectorException;
+
+    /**
+     * Get the text content of this node. Can be null.
+     * @param e the Node to check
+     * @return the text content
+     */
+    String getTextContent(E e);
+
+    /**
+     * This is a somewhat compromise for DOM where getChildNodes() is allowed to return other kind of nodes and not only
+     * ELEMENT_NODEs. With this method a Node e can be checked if it's actually a ELEMENT_NODE. For other trees this
+     * method might always return true.
+     *
+     * @param e The Node to check
+     * @return true if the Node is a ElementNode and false if not (probably only applicable to DOM-Implementations)
+     */
+    boolean isElementNode(E e);
+
+    /**
+     * Should comparing tags be processed case sensitive or not.
+     *
+     * @param e the root node
+     * @return return true to use case sensitive comparison and false if not.
+     */
+    boolean isCaseSensitive(E e);
+}

--- a/src/main/java/se/fishtank/css/selectors/generic/GenericNodeAdapterDOM.java
+++ b/src/main/java/se/fishtank/css/selectors/generic/GenericNodeAdapterDOM.java
@@ -1,0 +1,123 @@
+package se.fishtank.css.selectors.generic;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import se.fishtank.css.selectors.NodeSelectorException;
+import se.fishtank.css.selectors.dom.DOMHelper;
+import se.fishtank.css.util.Assert;
+
+public class GenericNodeAdapterDOM implements GenericNodeAdapter<Node> {
+
+    @Override
+    public Map<String, String> getAttributes(final Node node) {
+        Map<String, String> result = new HashMap<String, String>();
+    
+        NamedNodeMap map = node.getAttributes();
+        for (int i=0; i<map.getLength(); i++) {
+            Node n = map.item(i);
+            result.put(n.getNodeName(), n.getNodeValue());
+        }
+    
+        return result;
+    }
+  
+    @Override
+    public List<Node> getChildNodes(final Node e) {
+        List<Node> result = new ArrayList<Node>();
+    
+        NodeList nl = e.getChildNodes();
+        for (int i = 0; i < nl.getLength(); i++) {
+            result.add(nl.item(i));
+        }
+    
+        return result;
+    }
+  
+    @Override
+    public boolean isEmptyNode(final Node n) {
+        if (n.getNodeType() == Node.ELEMENT_NODE) {
+            return true;
+        }
+        if (n.getNodeType() == Node.TEXT_NODE) {
+            // TODO: Should we trim the text and see if it's length 0?
+            String value = n.getNodeValue();
+            if (value.length() > 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public Node getPreviousSiblingElement(final Node e) {
+        return DOMHelper.getPreviousSiblingElement(e);
+    }
+
+    @Override
+    public String getNodeName(final Node e) {
+        return e.getNodeName();
+    }
+
+    @Override
+    public Node getNextSiblingElement(final Node e) {
+        return DOMHelper.getNextSiblingElement(e);
+    }
+
+    @Override
+    public Node getRootNode(final Node root) {
+        if (root.getNodeType() == Node.DOCUMENT_NODE) {
+            // Get the single element child of the document node.
+            // There could be a doctype node and comment nodes that we must skip.
+            Element element = DOMHelper.getFirstChildElement(root);
+            Assert.notNull(element, "there should be a root element!");
+            return element;
+        } else {
+            Assert.isTrue(root.getNodeType() == Node.ELEMENT_NODE, "root must be a document or element node!");
+            return root;
+        }
+    }
+
+    @Override
+    public List<Node> getNodesByTagName(Node node, String tagName) throws NodeSelectorException {
+        List<Node> result = new ArrayList<Node>();
+        
+        NodeList nl;
+        if (node.getNodeType() == Node.DOCUMENT_NODE) {
+            nl = ((Document) node).getElementsByTagName(tagName);
+        } else if (node.getNodeType() == Node.ELEMENT_NODE) {
+            nl = ((Element) node).getElementsByTagName(tagName);
+        } else {
+            throw new NodeSelectorException("Only document and element nodes allowed!");
+        }
+
+        for (int i = 0; i < nl.getLength(); i++) {
+            result.add(nl.item(i));
+        }    
+        return result;
+    }
+
+    @Override
+    public String getTextContent(final Node e) {
+        return e.getTextContent();
+    }
+
+    @Override
+    public boolean isElementNode(Node e) {
+        return e.getNodeType() == Node.ELEMENT_NODE;
+    }
+
+    @Override
+    public boolean isCaseSensitive(Node root) {
+      Document doc = (root instanceof Document) ? (Document) root : root.getOwnerDocument();
+      return !doc.createElement("a").isEqualNode(doc.createElement("A"));
+    }
+}

--- a/src/main/java/se/fishtank/css/selectors/generic/GenericNodeSelector.java
+++ b/src/main/java/se/fishtank/css/selectors/generic/GenericNodeSelector.java
@@ -1,0 +1,171 @@
+package se.fishtank.css.selectors.generic;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import se.fishtank.css.selectors.NodeSelector;
+import se.fishtank.css.selectors.NodeSelectorException;
+import se.fishtank.css.selectors.Selector;
+import se.fishtank.css.selectors.Selectors;
+import se.fishtank.css.selectors.Specifier;
+import se.fishtank.css.selectors.generic.internal.GenericAttributeSpecifierChecker;
+import se.fishtank.css.selectors.generic.internal.GenericNodeTraversalChecker;
+import se.fishtank.css.selectors.generic.internal.GenericPseudoClassSpecifierChecker;
+import se.fishtank.css.selectors.generic.internal.GenericPseudoContainsSpecifierChecker;
+import se.fishtank.css.selectors.generic.internal.GenericPseudoNthSpecifierChecker;
+import se.fishtank.css.selectors.generic.internal.GenericTagChecker;
+import se.fishtank.css.selectors.specifier.AttributeSpecifier;
+import se.fishtank.css.selectors.specifier.NegationSpecifier;
+import se.fishtank.css.selectors.specifier.PseudoClassSpecifier;
+import se.fishtank.css.selectors.specifier.PseudoContainsSpecifier;
+import se.fishtank.css.selectors.specifier.PseudoNthSpecifier;
+import se.fishtank.css.util.Assert;
+
+/**
+ * A GenericNodeSelector for some unspecified E.
+ *
+ * @param <E> the generic node this class works with
+ */
+public class GenericNodeSelector<E> implements NodeSelector<E> {
+
+    /** The GenericNodeAdapter to use */
+    private GenericNodeAdapter<E> nodeAdapter;
+
+    /** The root node */
+    private final E root;
+
+    /**
+     * Create a new instance.
+     * 
+     * @param nodeAdapter The GenericNodeAdapter to do all the processing / translating to your real Node.
+     * @param root The root node. Must be a NiftyNode.
+     */
+    public GenericNodeSelector(final GenericNodeAdapter<E> nodeAdapter, final E root) {
+        Assert.notNull(nodeAdapter, "nodeAdapter is null!");
+        Assert.notNull(root, "root is null!");
+
+        this.nodeAdapter = nodeAdapter;
+        this.root = root;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public E querySelector(String selectors) throws NodeSelectorException {
+        return querySelector(Selectors.fromString(selectors));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public E querySelector(Selectors selectors) throws NodeSelectorException {
+        Set<E> result = querySelectorAll(selectors);
+        if (result.isEmpty()) {
+            return null;
+        }
+
+        return result.iterator().next();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Set<E> querySelectorAll(String selectors) throws NodeSelectorException {
+        return querySelectorAll(Selectors.fromString(selectors));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Set<E> querySelectorAll(Selectors selectors) throws NodeSelectorException {
+        Assert.notNull(selectors, "selectors is null!");
+        Set<E> results = new LinkedHashSet<E>();
+        for (List<Selector> parts : selectors.getGroups()) {
+            Set<E> result = check(parts);
+            if (!result.isEmpty()) {
+                results.addAll(result);
+            }
+        }
+
+        return results;
+    }
+
+    /**
+     * Check the list of selector <em>parts</em> and return a set of nodes with the result.
+     * 
+     * @param parts A list of selector <em>parts</em>.
+     * @return A set of nodes.
+     * @throws NodeSelectorException In case of an error.
+     */
+    private Set<E> check(final List<Selector> parts) throws NodeSelectorException {
+        Set<E> result = new LinkedHashSet<E>();
+        result.add(root);
+        for (Selector selector : parts) {
+            GenericNodeTraversalChecker<E> checker = new GenericTagChecker<E>(nodeAdapter, selector);
+            result = checker.check(result, root);
+            if (selector.hasSpecifiers()) {
+                for (Specifier specifier : selector.getSpecifiers()) {
+                    switch (specifier.getType()) {
+                    case ATTRIBUTE:
+                        checker = new GenericAttributeSpecifierChecker<E>(nodeAdapter, (AttributeSpecifier) specifier);
+                        break;
+                    case PSEUDO:
+                        if (specifier instanceof PseudoClassSpecifier) {
+                            checker = new GenericPseudoClassSpecifierChecker<E>(nodeAdapter, (PseudoClassSpecifier) specifier);
+                        } else if (specifier instanceof PseudoNthSpecifier) {
+                            checker = new GenericPseudoNthSpecifierChecker<E>(nodeAdapter, (PseudoNthSpecifier) specifier);
+                        } else if (specifier instanceof PseudoContainsSpecifier) {
+                          checker = new GenericPseudoContainsSpecifierChecker<E>(nodeAdapter, (PseudoContainsSpecifier) specifier);
+                        }
+                        
+                        break;
+                    case NEGATION:
+                        final Set<E> negationNodes = checkNegationSpecifier((NegationSpecifier) specifier);
+                        checker = new GenericNodeTraversalChecker<E>() {
+                            @Override
+                            public Set<E> check(Set<E> nodes, E root) throws NodeSelectorException {
+                                Set<E> set = new LinkedHashSet<E>(nodes);
+                                set.removeAll(negationNodes);
+                                return set;
+                            }
+                        };
+                        
+                        break;
+                    }
+                    
+                    result = checker.check(result, root);
+                    if (result.isEmpty()) {
+                        // Bail out early.
+                        return result;
+                    }
+                }
+            }
+        }
+        
+        return result;
+    }
+    
+    /**
+     * Check the {@link NegationSpecifier}.
+     * <p/>
+     * This method will add the {@link Selector} from the specifier in
+     * a list and invoke {@link #check(List)} with that list as the argument.
+     *  
+     * @param specifier The negation specifier.
+     * @return A set of nodes after invoking {@link #check(List)}.
+     * @throws NodeSelectorException In case of an error.
+     */
+    private Set<E> checkNegationSpecifier(final NegationSpecifier specifier) throws NodeSelectorException {
+        List<Selector> parts = new ArrayList<Selector>(1);
+        parts.add(specifier.getSelector());
+        return check(parts);
+    }
+    
+}
+

--- a/src/main/java/se/fishtank/css/selectors/generic/internal/GenericAttributeSpecifierChecker.java
+++ b/src/main/java/se/fishtank/css/selectors/generic/internal/GenericAttributeSpecifierChecker.java
@@ -1,0 +1,114 @@
+package se.fishtank.css.selectors.generic.internal;
+
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+import se.fishtank.css.selectors.NodeSelectorException;
+import se.fishtank.css.selectors.dom.internal.NodeTraversalChecker;
+import se.fishtank.css.selectors.generic.GenericNodeAdapter;
+import se.fishtank.css.selectors.specifier.AttributeSpecifier;
+import se.fishtank.css.util.Assert;
+
+/**
+ * A {@link NodeTraversalChecker} that check if a node's attribute
+ * matches the {@linkplain AttributeSpecifier attribute specifier} set.
+ * 
+ * @author Christer Sandberg
+ * @author Jens Hohmuth
+ */
+public class GenericAttributeSpecifierChecker<E> extends GenericNodeTraversalChecker<E> {
+
+    /** The generic node adapter */
+    private final GenericNodeAdapter<E> nodeAdapter;
+
+    /** The attribute specifier to check against. */
+    private final AttributeSpecifier specifier;
+   
+    /**
+     * Create a new instance.
+     * 
+     * @param specifier The attribute specifier to check against. 
+     */
+    public GenericAttributeSpecifierChecker(final GenericNodeAdapter<E> nodeAdapter, final AttributeSpecifier specifier) {
+        Assert.notNull(nodeAdapter, "nodeAdapter is null!");
+        Assert.notNull(specifier, "specifier is null!");
+
+        this.nodeAdapter = nodeAdapter;
+        this.specifier = specifier;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Set<E> check(Set<E> nodes, E root) throws NodeSelectorException {
+        Assert.notNull(nodes, "nodes is null!");
+        Set<E> result = new LinkedHashSet<E>();
+        for (E node : nodes) {
+            Map<String, String> map = nodeAdapter.getAttributes(node);
+            if (map == null) {
+                continue;
+            }
+            
+            String attr = map.get(specifier.getName());
+            if (attr == null) {
+                continue;
+            }
+            
+            // It just have to be present.
+            if (specifier.getValue() == null) {
+                result.add(node);
+                continue;
+            }
+            
+            String value = attr.trim();
+            if (value.length() != 0) {
+                String val = specifier.getValue();
+                switch (specifier.getMatch()) {
+                case EXACT:
+                    if (value.equals(val)) {
+                        result.add(node);
+                    }
+                    
+                    break;
+                case HYPHEN:
+                    if (value.equals(val) || value.startsWith(val + '-')) {
+                        result.add(node);
+                    }
+                    
+                    break;
+                case PREFIX:
+                    if (value.startsWith(val)) {
+                        result.add(node);
+                    }
+                    
+                    break;
+                case SUFFIX:
+                    if (value.endsWith(val)) {
+                        result.add(node);
+                    }
+                    
+                    break;
+                case CONTAINS:
+                    if (value.contains(val)) {
+                        result.add(node);
+                    }
+                    
+                    break;
+                case LIST:
+                    for (String v : value.split("\\s+")) {
+                        if (v.equals(val)) {
+                            result.add(node);
+                        }
+                    }
+                    
+                    break;
+                }
+            }
+        }
+        
+        return result;
+    }
+
+}

--- a/src/main/java/se/fishtank/css/selectors/generic/internal/GenericNodeTraversalChecker.java
+++ b/src/main/java/se/fishtank/css/selectors/generic/internal/GenericNodeTraversalChecker.java
@@ -1,0 +1,26 @@
+package se.fishtank.css.selectors.generic.internal;
+
+import java.util.Set;
+
+import se.fishtank.css.selectors.NodeSelectorException;
+
+/**
+ * An abstract base class for <em>checkers</em> that traverses nodes.
+ * 
+ * @author Christer Sandberg
+ * @author Jens Hohmuth
+ */
+public abstract class GenericNodeTraversalChecker<E> {
+    
+    /**
+     * Check the specified nodes and return a new {@code Set} containing
+     * the nodes that passed the check.
+     * 
+     * @param nodes The nodes to check.
+     * @param root The root node.
+     * @return A {@link Set} of nodes that passed the check.
+     * @throws NodeSelectorException If an error occurred while performing the check.
+     */
+    public abstract Set<E> check(Set<E> nodes, E root) throws NodeSelectorException;
+    
+}

--- a/src/main/java/se/fishtank/css/selectors/generic/internal/GenericPseudoClassSpecifierChecker.java
+++ b/src/main/java/se/fishtank/css/selectors/generic/internal/GenericPseudoClassSpecifierChecker.java
@@ -1,0 +1,237 @@
+package se.fishtank.css.selectors.generic.internal;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import se.fishtank.css.selectors.NodeSelectorException;
+import se.fishtank.css.selectors.dom.internal.NodeTraversalChecker;
+import se.fishtank.css.selectors.generic.GenericNodeAdapter;
+import se.fishtank.css.selectors.specifier.PseudoClassSpecifier;
+import se.fishtank.css.util.Assert;
+
+/**
+ * A {@link NodeTraversalChecker} that check if a node matches
+ * the {@linkplain PseudoClassSpecifier pseudo-class specifier} set.
+ * 
+ * @author Christer Sandberg
+ * @author Jens Hohmuth
+ */
+public class GenericPseudoClassSpecifierChecker<E> extends GenericNodeTraversalChecker<E> {
+    
+    /** The generic node adapter */
+    private final GenericNodeAdapter<E> nodeAdapter;
+
+    /** The pseudo-class specifier to check against. */
+    private final PseudoClassSpecifier specifier;
+    
+    /** The set of nodes to check. */
+    private Set<E> nodes;
+
+    /** The root node. */
+    private E root;
+    
+    /** The result of the checks. */
+    private Set<E> result;
+    
+    /**
+     * Create a new instance.
+     * 
+     * @param specifier The pseudo-class specifier to check against.
+     */
+    public GenericPseudoClassSpecifierChecker(GenericNodeAdapter<E> nodeAdapter, PseudoClassSpecifier specifier) {
+        Assert.notNull(nodeAdapter, "nodeAdapter is null!");
+        Assert.notNull(specifier, "specifier is null!");
+
+        this.nodeAdapter = nodeAdapter;
+        this.specifier = specifier;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Set<E> check(Set<E> nodes, E root) throws NodeSelectorException {
+        Assert.notNull(nodes, "nodes is null!");
+        Assert.notNull(root, "root is null!");
+        this.nodes = nodes;
+        this.root = root;
+        result = new LinkedHashSet<E>();
+        String value = specifier.getValue();
+        if ("empty".equals(value)) {
+            addEmptyElements();
+        } else if ("first-child".equals(value)) {
+            addFirstChildElements();
+        } else if ("first-of-type".equals(value)) {
+            addFirstOfType();
+        } else if ("last-child".equals(value)) {
+            addLastChildElements();
+        } else if ("last-of-type".equals(value)) {
+            addLastOfType();
+        } else if ("only-child".equals(value)) {
+            addOnlyChildElements();
+        } else if ("only-of-type".equals(value)) {
+            addOnlyOfTypeElements();
+        } else if ("root".equals(value)) {
+            addRootElement();
+        } else {
+            throw new NodeSelectorException("Unknown pseudo class: " + value);
+        }
+        
+        return result;
+    }
+
+    /**
+     * Add {@code :empty} elements.
+     * 
+     * @see <a href="http://www.w3.org/TR/css3-selectors/#empty-pseudo"><code>:empty</code> pseudo-class</a>
+     */
+    private void addEmptyElements() {
+        for (E node : nodes) {
+            boolean empty = true;
+            List<E> nl = nodeAdapter.getChildNodes(node);
+            for (int i = 0; i < nl.size(); i++) {
+                E n = nl.get(i);
+                if (nodeAdapter.isEmptyNode(n)) {
+                    empty = false;
+                    break;
+                }
+            }
+            
+            if (empty) {
+                result.add(node);
+            }
+        }
+    }
+    
+    /**
+     * Add {@code :first-child} elements.
+     * 
+     * @see <a href="http://www.w3.org/TR/css3-selectors/#first-child-pseudo"><code>:first-child</code> pseudo-class</a>
+     */
+    private void addFirstChildElements() {
+        for (E node : nodes) {
+            if (nodeAdapter.getPreviousSiblingElement(node) == null) {
+                result.add(node);
+            }
+        }
+    }
+    
+    /**
+     * Add {@code :first-of-type} elements.
+     * 
+     * @see <a href="http://www.w3.org/TR/css3-selectors/#first-of-type-pseudo"><code>:first-of-type</code> pseudo-class</a>
+     */
+    private void addFirstOfType() {
+        for (E node : nodes) {
+            E n = nodeAdapter.getPreviousSiblingElement(node);
+            while (n != null) {
+                String nodeName = nodeAdapter.getNodeName(n);
+                if (nodeName != null && nodeName.equals(nodeAdapter.getNodeName(node))) {
+                    break;
+                }
+                
+                n = nodeAdapter.getPreviousSiblingElement(n);
+            }
+            
+            if (n == null) {
+                result.add(node);
+            }
+        }
+    }
+
+    /**
+     * Add {@code :last-child} elements.
+     * 
+     * @see <a href="http://www.w3.org/TR/css3-selectors/#last-child-pseudo"><code>:last-child</code> pseudo-class</a>
+     */
+    private void addLastChildElements() {
+        for (E node : nodes) {
+            if (nodeAdapter.getNextSiblingElement(node) == null) {
+                result.add(node);
+            }
+        }
+    }
+    
+    /**
+     * Add {@code :last-of-type} elements.
+     * 
+     * @see <a href="http://www.w3.org/TR/css3-selectors/#last-of-type-pseudo"><code>:last-of-type</code> pseudo-class</a>
+     */
+    private void addLastOfType() {
+        for (E node : nodes) {
+            E n = nodeAdapter.getNextSiblingElement(node);
+            while (n != null) {
+              String nodeName = nodeAdapter.getNodeName(n);
+                if (nodeName != null && nodeName.equals(nodeAdapter.getNodeName(node))) {
+                    break;
+                }
+                
+                n = nodeAdapter.getNextSiblingElement(n);
+            }
+            
+            if (n == null) {
+                result.add(node);
+            }
+        }
+    }
+    
+    /**
+     * Add {@code :only-child} elements.
+     * 
+     * @see <a href="http://www.w3.org/TR/css3-selectors/#only-child-pseudo"><code>:only-child</code> pseudo-class</a>
+     */
+    private void addOnlyChildElements() {
+        for (E node : nodes) {
+            if (nodeAdapter.getPreviousSiblingElement(node) == null &&
+                nodeAdapter.getNextSiblingElement(node) == null) {
+                result.add(node);
+            }
+        }
+    }
+    
+    /**
+     * Add {@code :only-of-type} elements.
+     * 
+     * @see <a href="http://www.w3.org/TR/css3-selectors/#only-of-type-pseudo"><code>:only-of-type</code> pseudo-class</a>
+     */
+    private void addOnlyOfTypeElements() {
+        for (E node : nodes) {
+            E n = nodeAdapter.getPreviousSiblingElement(node);
+            while (n != null) {
+                String nodeName = nodeAdapter.getNodeName(n);
+                if (nodeName != null && nodeName.equals(nodeAdapter.getNodeName(node))) {
+                    break;
+                }
+                
+                n = nodeAdapter.getPreviousSiblingElement(n);
+            }
+            
+            if (n == null) {
+                n = nodeAdapter.getNextSiblingElement(node);
+                while (n != null) {
+                    String nodeName = nodeAdapter.getNodeName(n);
+                    if (nodeName != null && nodeName.equals(nodeAdapter.getNodeName(node))) {
+                        break;
+                    }
+                    
+                    n = nodeAdapter.getNextSiblingElement(n);
+                }
+                
+                if (n == null) {
+                    result.add(node);
+                }
+            }
+        }
+    }
+
+    /**
+     * Add the {@code :root} element.
+     * 
+     * @see <a href="http://www.w3.org/TR/css3-selectors/#root-pseudo"><code>:root</code> pseudo-class</a>
+     */
+    private void addRootElement() {
+        result.add(nodeAdapter.getRootNode(root));
+    }
+    
+}

--- a/src/main/java/se/fishtank/css/selectors/generic/internal/GenericPseudoContainsSpecifierChecker.java
+++ b/src/main/java/se/fishtank/css/selectors/generic/internal/GenericPseudoContainsSpecifierChecker.java
@@ -1,0 +1,61 @@
+package se.fishtank.css.selectors.generic.internal;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import se.fishtank.css.selectors.NodeSelectorException;
+import se.fishtank.css.selectors.dom.internal.NodeTraversalChecker;
+import se.fishtank.css.selectors.generic.GenericNodeAdapter;
+import se.fishtank.css.selectors.specifier.PseudoContainsSpecifier;
+import se.fishtank.css.util.Assert;
+
+/**
+ * A {@link NodeTraversalChecker} that check if a node matches
+ * the {@linkplain PseudoContainsSpecifier pseudo-class specifier} set.
+ * 
+ * Checks for {@code a:contains('some text')} selector matches.
+ * 
+ * @author John Heintz
+ * @author Christer Sandberg
+ * @author Jens Hohmuth
+ */
+public class GenericPseudoContainsSpecifierChecker<E> extends GenericNodeTraversalChecker<E> {
+    
+    /** The generic node adapter */
+    private final GenericNodeAdapter<E> nodeAdapter;
+
+    /** The pseudo-class specifier to check against. */
+    private final PseudoContainsSpecifier specifier;
+    
+    /**
+     * Create a new instance.
+     * 
+     * @param specifier The pseudo-class specifier to check against.
+     */
+    public GenericPseudoContainsSpecifierChecker(GenericNodeAdapter<E> nodeAdapter, PseudoContainsSpecifier specifier) {
+        Assert.notNull(nodeAdapter, "nodeAdapter is null!");
+        Assert.notNull(specifier, "specifier is null!");
+
+        this.nodeAdapter = nodeAdapter;
+        this.specifier = specifier;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Set<E> check(Set<E> nodes, E root) throws NodeSelectorException {
+        Assert.notNull(nodes, "nodes is null!");
+        Assert.notNull(root, "root is null!");
+        LinkedHashSet<E> result = new LinkedHashSet<E>();
+        String value = specifier.getValue();
+        for (E node : nodes) {
+        	String textContent = nodeAdapter.getTextContent(node);
+          if (textContent != null && textContent.contains(value)) {
+        		result.add(node);
+        	}
+        }
+        
+        return result;
+    }
+}

--- a/src/main/java/se/fishtank/css/selectors/generic/internal/GenericPseudoNthSpecifierChecker.java
+++ b/src/main/java/se/fishtank/css/selectors/generic/internal/GenericPseudoNthSpecifierChecker.java
@@ -1,0 +1,158 @@
+package se.fishtank.css.selectors.generic.internal;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import se.fishtank.css.selectors.NodeSelectorException;
+import se.fishtank.css.selectors.dom.internal.NodeTraversalChecker;
+import se.fishtank.css.selectors.generic.GenericNodeAdapter;
+import se.fishtank.css.selectors.specifier.PseudoNthSpecifier;
+import se.fishtank.css.util.Assert;
+
+/**
+ * A {@link NodeTraversalChecker} that check if a node matches
+ * the {@code nth-*} {@linkplain PseudoNthSpecifier pseudo-class specifier} set.
+ * 
+ * @author Christer Sandberg
+ * @author Jens Hohmuth
+ */
+public class GenericPseudoNthSpecifierChecker<E> extends GenericNodeTraversalChecker<E> {
+    
+    /** The generic node adapter */
+    private final GenericNodeAdapter<E> nodeAdapter;
+
+    /** The {@code nth-*} pseudo-class specifier to check against. */
+    private final PseudoNthSpecifier specifier;
+    
+    /** The set of nodes to check. */
+    private Set<E> nodes;
+    
+    /** The result of the checks. */
+    private Set<E> result;
+    
+    /**
+     * Create a new instance.
+     * 
+     * @param specifier The {@code nth-*} pseudo-class specifier to check against.
+     */
+    public GenericPseudoNthSpecifierChecker(GenericNodeAdapter<E> nodeAdapter, PseudoNthSpecifier specifier) {
+        Assert.notNull(nodeAdapter, "nodeAdapter is null!");
+        Assert.notNull(specifier, "specifier is null!");
+
+        this.nodeAdapter = nodeAdapter;
+        this.specifier = specifier;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Set<E> check(Set<E> nodes, E root) throws NodeSelectorException {
+        Assert.notNull(nodes, "nodes is null!");
+        this.nodes = nodes;
+        result = new LinkedHashSet<E>();
+        String value = specifier.getValue();
+        if ("nth-child".equals(value)) {
+            addNthChild();
+        } else if ("nth-last-child".equals(value)) {
+            addNthLastChild();
+        } else if ("nth-of-type".equals(value)) {
+            addNthOfType();
+        } else if ("nth-last-of-type".equals(value)) {
+            addNthLastOfType();
+        } else {
+            throw new NodeSelectorException("Unknown pseudo nth class: " + value);
+        }
+        
+        return result;
+    }
+    
+    /**
+     * Add the {@code :nth-child} elements.
+     * 
+     * @see <a href="http://www.w3.org/TR/css3-selectors/#nth-child-pseudo"><code>:nth-child</code> pseudo-class</a>
+     */
+    private void addNthChild() {
+        for (E node : nodes) {
+            int count = 1;
+            E n = nodeAdapter.getPreviousSiblingElement(node);
+            while (n != null) {
+                count++;
+                n = nodeAdapter.getPreviousSiblingElement(n);
+            }
+            
+            if (specifier.isMatch(count)) {
+                result.add(node);
+            }
+        }
+    }
+    
+    /**
+     * Add {@code :nth-last-child} elements.
+     * 
+     * @see <a href="http://www.w3.org/TR/css3-selectors/#nth-last-child-pseudo"><code>:nth-last-child</code> pseudo-class</a>
+     */
+    private void addNthLastChild() {
+        for (E node : nodes) {
+            int count = 1;
+            E n = nodeAdapter.getNextSiblingElement(node);
+            while (n != null) {
+                count++;
+                n = nodeAdapter.getNextSiblingElement(n);
+            }
+            
+            if (specifier.isMatch(count)) {
+                result.add(node);
+            }
+        }
+    }
+    
+    /**
+     * Add {@code :nth-of-type} elements.
+     * 
+     * @see <a href="http://www.w3.org/TR/css3-selectors/#nth-of-type-pseudo"><code>:nth-of-type</code> pseudo-class</a>
+     */
+    private void addNthOfType() {
+        for (E node : nodes) {
+            int count = 1;
+            E n = nodeAdapter.getPreviousSiblingElement(node);
+            while (n != null) {
+                String nodeName = nodeAdapter.getNodeName(n);
+                if (nodeName != null && nodeName.equals(nodeAdapter.getNodeName(node))) {
+                    count++;
+                }
+                
+                n = nodeAdapter.getPreviousSiblingElement(n);
+            }
+            
+            if (specifier.isMatch(count)) {
+                result.add(node);
+            }
+        }
+    }
+    
+    /**
+     * Add {@code nth-last-of-type} elements.
+     * 
+     * @see <a href="http://www.w3.org/TR/css3-selectors/#nth-last-of-type-pseudo"><code>:nth-last-of-type</code> pseudo-class</a>
+     */
+    private void addNthLastOfType() {
+        for (E node : nodes) {
+            int count = 1;
+            E n = nodeAdapter.getNextSiblingElement(node);
+            while (n != null) {
+                String nodeName = nodeAdapter.getNodeName(n);
+                if (nodeName != null && nodeName.equals(nodeAdapter.getNodeName(node))) {
+                    count++;
+                }
+                
+                n = nodeAdapter.getNextSiblingElement(n);
+            }
+            
+            if (specifier.isMatch(count)) {
+                result.add(node);
+            }
+        }
+    }
+    
+}

--- a/src/main/java/se/fishtank/css/selectors/generic/internal/GenericTagChecker.java
+++ b/src/main/java/se/fishtank/css/selectors/generic/internal/GenericTagChecker.java
@@ -1,0 +1,165 @@
+package se.fishtank.css.selectors.generic.internal;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import se.fishtank.css.selectors.NodeSelectorException;
+import se.fishtank.css.selectors.Selector;
+import se.fishtank.css.selectors.dom.internal.NodeTraversalChecker;
+import se.fishtank.css.selectors.generic.GenericNodeAdapter;
+import se.fishtank.css.util.Assert;
+
+/**
+ * A {@link NodeTraversalChecker} that check if a node
+ * matches the {@linkplain Selector#getTagName() tag name} and
+ * {@linkplain Selector#getCombinator() combinator} of the {@link Selector} set.
+ * 
+ * @author Christer Sandberg
+ * @author Jens Hohmuth
+ */
+public class GenericTagChecker<E> extends GenericNodeTraversalChecker<E> {
+
+    /** The GenericNodeAdapter to use */
+    private GenericNodeAdapter<E> nodeAdapter;
+
+    /** The selector to check against. */
+    private final Selector selector;
+    
+    /** The set of nodes to check. */
+    private Set<E> nodes;
+    
+    /** The result of the checks. */
+    private Set<E> result;
+
+    /** Whether the underlying DOM is case sensitive. */
+    private boolean caseSensitive;
+    
+    /**
+     * Create a new instance.
+     * 
+     * @param selector The selector to check against.
+     */
+    public GenericTagChecker(GenericNodeAdapter<E> nodeAdapter, Selector selector) {
+        Assert.notNull(nodeAdapter, "nodeAdapter is null!");
+        Assert.notNull(selector, "selector is null!");
+
+        this.nodeAdapter = nodeAdapter;
+        this.selector = selector;
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Set<E> check(Set<E> nodes, E root) throws NodeSelectorException {
+        Assert.notNull(nodes, "nodes is null!");
+        this.nodes = nodes;
+        this.caseSensitive = nodeAdapter.isCaseSensitive(root);
+
+        result = new LinkedHashSet<E>();
+        switch (selector.getCombinator()) {
+        case DESCENDANT:
+            addDescendantElements();
+            break;
+        case CHILD:
+            addChildElements();
+            break;
+        case ADJACENT_SIBLING:
+            addAdjacentSiblingElements();
+            break;
+        case GENERAL_SIBLING:
+            addGeneralSiblingElements();
+            break;
+        }
+        
+        return result;
+    }
+    
+    /**
+     * Add descendant elements.
+     * 
+     * @see <a href="http://www.w3.org/TR/css3-selectors/#descendant-combinators">Descendant combinator</a>
+     * 
+     * @throws NodeSelectorException If one of the nodes have an illegal type.
+     */
+    private void addDescendantElements() throws NodeSelectorException {
+        for (E node : nodes) {
+            result.addAll(nodeAdapter.getNodesByTagName(node, selector.getTagName()));
+        }
+    }
+    
+    /**
+     * Add child elements.
+     * 
+     * @see <a href="http://www.w3.org/TR/css3-selectors/#child-combinators">Child combinators</a>
+     */
+    private void addChildElements() {
+        for (E node : nodes) {
+            List<E> nl = nodeAdapter.getChildNodes(node);
+            for (int i = 0; i < nl.size(); i++) {
+                node = nl.get(i);
+                if (!nodeAdapter.isElementNode(node)) {
+                    continue;
+                }
+                
+                String tag = selector.getTagName();
+                if (tagEquals(tag, nodeAdapter.getNodeName(node)) || tag.equals(Selector.UNIVERSAL_TAG)) {
+                    result.add(node);
+                }
+            }
+        }
+    }
+    
+    /**
+     * Add adjacent sibling elements.
+     * 
+     * @see <a href="http://www.w3.org/TR/css3-selectors/#adjacent-sibling-combinators">Adjacent sibling combinator</a>
+     */
+    private void addAdjacentSiblingElements() {
+        for (E node : nodes) {
+            E n = nodeAdapter.getNextSiblingElement(node);
+            if (n != null) {
+                String tag = selector.getTagName();
+                if (tagEquals(tag, nodeAdapter.getNodeName(n)) || tag.equals(Selector.UNIVERSAL_TAG)) {
+                    result.add(n);
+                }
+            }
+        }
+    }
+    
+    /**
+     * Add general sibling elements.
+     * 
+     * @see <a href="http://www.w3.org/TR/css3-selectors/#general-sibling-combinators">General sibling combinator</a>
+     */
+    private void addGeneralSiblingElements() {
+        for (E node : nodes) {
+            E n = nodeAdapter.getNextSiblingElement(node);
+            while (n != null) {
+                String tag = selector.getTagName();
+                if (tagEquals(tag, nodeAdapter.getNodeName(n)) || tag.equals(Selector.UNIVERSAL_TAG)) {
+                    result.add(n);
+                }
+                
+                n = nodeAdapter.getNextSiblingElement(n);
+            }
+        }
+    }
+
+    /**
+     * Determine if the two specified tag names are equal.
+     *
+     * @param tag1 A tag name.
+     * @param tag2 A tag name.
+     * @return <code>true</code> if the tag names are equal, <code>false</code> otherwise.
+     */
+    private boolean tagEquals(String tag1, String tag2) {
+        if (caseSensitive) {
+            return tag1.equals(tag2);
+        }
+
+        return tag1.equalsIgnoreCase(tag2);
+    }
+
+}

--- a/src/test/java/se/fishtank/css/selectors/GenericNodeSelectorDOMAntonBugTest.java
+++ b/src/test/java/se/fishtank/css/selectors/GenericNodeSelectorDOMAntonBugTest.java
@@ -1,0 +1,37 @@
+package se.fishtank.css.selectors;
+
+import java.util.Set;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+
+import se.fishtank.css.selectors.generic.GenericNodeAdapterDOM;
+import se.fishtank.css.selectors.generic.GenericNodeSelector;
+
+public class GenericNodeSelectorDOMAntonBugTest {
+    
+    private final NodeSelector<Node> nodeSelector;
+    
+    public GenericNodeSelectorDOMAntonBugTest() throws Exception {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        Document document = factory.newDocumentBuilder().parse(getClass().getResourceAsStream("/anton-bug.xml"));
+        nodeSelector = new GenericNodeSelector<Node>(new GenericNodeAdapterDOM(), document);
+    }
+    
+    @Test
+    public void checkAdjacentSiblings() throws Exception {
+        Set<Node> result = nodeSelector.querySelectorAll("token[tag^=l] + token");
+        Assert.assertEquals(3, result.size());
+    }
+    
+    @Test
+    public void checkGeneralSiblings() throws Exception {
+        Set<Node> result = nodeSelector.querySelectorAll("token[tag^=l] ~ token");
+        Assert.assertEquals(6, result.size());
+    }
+    
+}

--- a/src/test/java/se/fishtank/css/selectors/GenericNodeSelectorDOMTest.java
+++ b/src/test/java/se/fishtank/css/selectors/GenericNodeSelectorDOMTest.java
@@ -1,0 +1,109 @@
+package se.fishtank.css.selectors;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+
+import se.fishtank.css.selectors.dom.DOMNodeSelector;
+import se.fishtank.css.selectors.generic.GenericNodeAdapterDOM;
+import se.fishtank.css.selectors.generic.GenericNodeSelector;
+
+public class GenericNodeSelectorDOMTest {
+    
+    private static final Map<String, Integer> testDataMap = new LinkedHashMap<String, Integer>();
+    
+    static {
+        testDataMap.put("h3:contains('palace')", 1);
+        testDataMap.put("h3:contains('in the palace')", 1);
+        testDataMap.put("*", 251);
+        testDataMap.put(":root", 1);
+        testDataMap.put(":empty", 2);
+        testDataMap.put("div:first-child", 51);
+        testDataMap.put("div:nth-child(even)", 106);
+        testDataMap.put("div:nth-child(2n)", 106);
+        testDataMap.put("div:nth-child(odd)", 137);
+        testDataMap.put("div:nth-child(2n+1)", 137);
+        testDataMap.put("div:nth-child(n)", 243);
+        testDataMap.put("script:first-of-type", 1);
+        testDataMap.put("div:last-child", 53);
+        testDataMap.put("script:last-of-type", 1);
+        testDataMap.put("script:nth-last-child(odd)", 1);
+        testDataMap.put("script:nth-last-child(even)", 1);
+        testDataMap.put("script:nth-last-child(5)", 0);
+        testDataMap.put("script:nth-of-type(2)", 1);
+        testDataMap.put("script:nth-last-of-type(n)", 2);
+        testDataMap.put("div:only-child", 22);
+        testDataMap.put("meta:only-of-type", 1);
+        testDataMap.put("div > div", 242);
+        testDataMap.put("div + div", 190);
+        testDataMap.put("div ~ div", 190);
+        testDataMap.put("body", 1);
+        testDataMap.put("body div", 243);
+        testDataMap.put("div", 243);
+        testDataMap.put("div div", 242);
+        testDataMap.put("div div div", 241);
+        testDataMap.put("div, div, div", 243);
+        testDataMap.put("div, a, span", 243);
+        testDataMap.put(".dialog", 51);
+        testDataMap.put("div.dialog", 51);
+        testDataMap.put("div .dialog", 51);
+        testDataMap.put("div.character, div.dialog", 99);
+        testDataMap.put("#speech5", 1);
+        testDataMap.put("div#speech5", 1);
+        testDataMap.put("div #speech5", 1);
+        testDataMap.put("div.scene div.dialog", 49);
+        testDataMap.put("div#scene1 div.dialog div", 142);
+        testDataMap.put("#scene1 #speech1", 1);
+        testDataMap.put("div[class]", 103);
+        testDataMap.put("div[class=dialog]", 50);
+        testDataMap.put("div[class^=dia]", 51);
+        testDataMap.put("div[class$=log]", 50);
+        testDataMap.put("div[class*=sce]", 1);
+        testDataMap.put("div[class|=dialog]", 50);
+        testDataMap.put("div[class~=dialog]", 51);
+        testDataMap.put("head > :not(meta)", 2);
+        testDataMap.put("head > :not(:last-child)", 2);
+        testDataMap.put("div:not(div.dialog)", 192);
+    }
+    
+    private final NodeSelector<Node> nodeSelector;
+    
+    public GenericNodeSelectorDOMTest() throws Exception {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        Document document = factory.newDocumentBuilder().parse(getClass().getResourceAsStream("/test.html"));
+        nodeSelector = new GenericNodeSelector<Node>(new GenericNodeAdapterDOM(), document);
+    }
+    
+    @Test
+    public void checkSelectors() throws Exception {
+        for (Map.Entry<String, Integer> entry : testDataMap.entrySet()) {
+            System.out.printf("selector: %s, expected: %d%n", entry.getKey(), entry.getValue());
+            Set<Node> result = nodeSelector.querySelectorAll(entry.getKey());
+            Assert.assertEquals(entry.getKey(), (int) entry.getValue(), (int) result.size());
+        }
+    }
+    
+    @Test
+    public void checkRoot() throws NodeSelectorException {
+        Node root = nodeSelector.querySelector(":root");
+        Assert.assertEquals(Node.ELEMENT_NODE, root.getNodeType());
+        Assert.assertEquals("html", root.getNodeName());
+        
+        DOMNodeSelector subSelector = new DOMNodeSelector(nodeSelector.querySelector("div#scene1"));
+        Set<Node> subRoot = subSelector.querySelectorAll(":root");
+        Assert.assertEquals(1, subRoot.size());
+        Assert.assertEquals("scene1", subRoot.iterator().next().getAttributes().getNamedItem("id").getTextContent());
+        Assert.assertEquals((int) testDataMap.get("div#scene1 div.dialog div"), subSelector.querySelectorAll(":root div.dialog div").size());
+        
+        Node meta = nodeSelector.querySelector(":root > head > meta");
+        Assert.assertEquals(meta, new DOMNodeSelector(meta).querySelector(":root"));
+    }
+    
+}


### PR DESCRIPTION
Implementing a custom NodeSelector for custom node tree structures (that
are not DOM based) is possible but requires quite a bit of effort to
support all possible selector combinations.

However, the DOM implementation in the se.fishtank.css.selectors.dom
package solves a lot of these common problems already but is - of course - very DOM specific.

This commit basically makes a generic version/copy of the dom package
with all of the specifics extracted into a GenericNodeAdapter interface.
The GenericNodeAdapter will provide all of the functionality that really
is specific to a Node tree and all the remaining Generic* classes
provide all of the common functionality that is shared between DOM and
other Node trees.

This way the user (or in this case, myself ;-) can use the NodeSelector
more easily with a custom node tree by simply providing an
implementation of the GenericNodeAdapter.

As a proof of concept I've provided a DOM implementation of
GenericNodeAdapter (GenericNodeAdapterDOM) and copied the test cases as
well, which pass without issues.

The GenericNodeAdapterDOM is eventually a little bit slower than the
original code since it requires some Lists and Maps to be instantiated
additonally (which was not required in the original DOM code). This is
because of the GenericNodeAdapter interface and it's way to communicate
to the rest of the system while keeping a good abstraction for the
interface. I'm not sure how much of a problem this really is but as far
as I see this is the only difference the "generic" version introduces.

I've left the original dom package as-is. Eventually it could be removed
in favour of the generic package in which case the "Generic*" could be
removed too. This way we don't have to maintain two packages in the
future but the original author is probably better to judge that :)